### PR TITLE
feat: add option to generate virtual keys for embedded collections without standalone links

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,115 @@ console.log(normalize(json, { embeddedStandaloneListKey: 'items' }));
 */
 ```
 
+## Virtual self for embedded collections without link
+
+For consistency, you might want to always have related collections referenceable, even if the API does not provide any single link under which the collection could be accessed in isolation.
+This library gives you the option to generate virtual keys (virtual URIs, virtual self links) for all embedded and linked arrays that don't already have a self link.
+To activate, set `embeddedStandaloneListVirtualKeys` to `true`.
+
+> Note: If the API also sends a single link for an embedded collection, this single link will be used instead of any virtual (generated) key, since that link will be more accurate and more useful to e.g. reload the collection from the API in isolation.
+
+The generated links are always marked with the `virtual: true` flag, so you can distinguish them from "normal" self links when doing further processing.
+
+```JavaScript
+const json = {
+  id: 1,
+  _embedded: {
+    comments: [
+      {
+        text: 'Hello World!',
+        author: 'James',
+        _links: {
+          self: {
+            href: 'https://my.api.com/comments/53204',
+          },
+        },
+      },
+      {
+        text: 'Hi there',
+        author: 'Joana',
+        _links: {
+          self: {
+            href: 'https://my.api.com/comments/1395',
+          },
+        },
+      },
+    ],
+  },
+  _links: {
+    users: [{
+      href: 'https://my.api.com/users/123',
+    }, {
+      href: 'https://my.api.com/users/324',
+    }],
+    self: {
+      href: 'https://my.api.com/someEntity/1',
+    },
+  },
+};
+
+console.log(normalize(json, { embeddedStandaloneListKey: 'items', embeddedStandaloneListVirtualKeys: true }));
+/* Output:
+{
+  'https://my.api.com/someEntity/1': {
+    id: 1,
+    comments: {
+      href: 'https://my.api.com/someEntity/1#comments',
+      virtual: true,
+    },
+    users: {
+      href: 'https://my.api.com/someEntity/1#users',
+      virtual: true,
+    },
+    _meta: {
+      self: 'https://my.api.com/someEntity/1',
+    },
+  },
+  'https://my.api.com/someEntity/1#comments': {
+    items: [
+      {
+        href: 'https://my.api.com/comments/53204',
+      },
+      {
+        href: 'https://my.api.com/comments/1395',
+      },
+    ],
+    _meta: {
+      self: 'https://my.api.com/someEntity/1#comments',
+      virtual: true,
+    },
+  },
+  'https://my.api.com/someEntity/1#users': {
+    items: [
+      {
+        href: 'https://my.api.com/users/123',
+      },
+      {
+        href: 'https://my.api.com/users/324',
+      },
+    ],
+    _meta: {
+      self: 'https://my.api.com/someEntity/1#users',
+      virtual: true,
+    },
+  },
+  'https://my.api.com/comments/53204': {
+    text: 'Hello World!',
+    author: 'James',
+    _meta: {
+      self: 'https://my.api.com/comments/53204'
+    },
+  }
+  'https://my.api.com/comments/1395': {
+    text: 'Hi there',
+    author: 'Joana',
+    _meta: {
+      self: 'https://my.api.com/comments/1395'
+    },
+  },
+}
+*/
+```
 
 ## Filtering references
 

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ console.log(normalize(json, { embeddedStandaloneListKey: 'items' }));
 
 For consistency, you might want to always have related collections referenceable, even if the API does not provide any single link under which the collection could be accessed in isolation.
 This library gives you the option to generate virtual keys (virtual URIs, virtual self links) for all embedded and linked arrays that don't already have a self link.
-To activate, set `embeddedStandaloneListVirtualKeys` to `true`.
+To activate, set `virtualSelfLinks` to `true`.
 
 > Note: If the API also sends a single link for an embedded collection, this single link will be used instead of any virtual (generated) key, since that link will be more accurate and more useful to e.g. reload the collection from the API in isolation.
 
@@ -402,7 +402,7 @@ const json = {
   },
 };
 
-console.log(normalize(json, { embeddedStandaloneListKey: 'items', embeddedStandaloneListVirtualKeys: true }));
+console.log(normalize(json, { embeddedStandaloneListKey: 'items', virtualSelfLinks: true }));
 /* Output:
 {
   'https://my.api.com/someEntity/1': {

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -132,8 +132,7 @@ function mergeEmbeddedStandaloneCollections(embedded, links, opts) {
             [opts.embeddedStandaloneListKey]: embedded[uri][rel],
             [opts.metaKey]: { self: links[uri][rel].href },
           };
-        } else if (opts.embeddedStandaloneListVirtualKeys
-          && rel !== opts.embeddedStandaloneListKey) {
+        } else if (opts.virtualSelfLinks && rel !== opts.embeddedStandaloneListKey) {
           // no standalone link provided --> generate virtual key
           delete ret[uri][rel];
           merge(
@@ -146,7 +145,7 @@ function mergeEmbeddedStandaloneCollections(embedded, links, opts) {
 
     // also check remaining link properties to search for a possible collection
     // which is not embedded
-    if (opts.embeddedStandaloneListVirtualKeys) {
+    if (opts.virtualSelfLinks) {
       difference(
         keys(links[uri]),
         [...keys(embedded[uri]), opts.embeddedStandaloneListKey],

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -1,6 +1,9 @@
-import {
-  camelCase, isArray, cloneDeep, keys, merge, difference,
-} from 'lodash';
+import camelCase from 'lodash/camelCase';
+import isArray from 'lodash/isArray';
+import cloneDeep from 'lodash/cloneDeep';
+import keys from 'lodash/keys';
+import merge from 'lodash/merge';
+import difference from 'lodash/difference';
 
 /* eslint no-underscore-dangle: ["error", { "allow": ["_links", "_embedded"] }] */
 

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -103,9 +103,9 @@ function mergeEmbeddedStandaloneCollections(embedded, links, opts) {
 
   keys(embedded).forEach((uri) => {
     keys(embedded[uri]).forEach((rel) => {
-      if (Array.isArray(embedded[uri][rel]) && uri in links && rel in links[uri]) {
+      if (Array.isArray(embedded[uri][rel])) {
         // standalone link provided (store embedded list as standalone link)
-        if (isSingleLink(links[uri][rel])) {
+        if (uri in links && rel in links[uri] && isSingleLink(links[uri][rel])) {
           ret[uri][rel] = links[uri][rel];
           ret[links[uri][rel].href] = {
             [opts.embeddedStandaloneListKey]: embedded[uri][rel],

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -97,11 +97,15 @@ function extractAllLinks(json, uri, opts) {
   return ret;
 }
 
-function extractToVirtualKey(uri, rel, content, contentKey) {
+function extractToVirtualKey(uri, rel, content, opts) {
   const ret = {};
   const virtualKey = `${uri}#${rel}`;
   ret[virtualKey] = {
-    [contentKey]: content,
+    [opts.embeddedStandaloneListKey]: content,
+    [opts.metaKey]: {
+      self: virtualKey,
+      virtual: true,
+    },
   };
 
   ret[uri] = {};
@@ -134,7 +138,7 @@ function mergeEmbeddedStandaloneCollections(embedded, links, opts) {
           delete ret[uri][rel];
           merge(
             ret,
-            extractToVirtualKey(uri, rel, embedded[uri][rel], opts.embeddedStandaloneListKey),
+            extractToVirtualKey(uri, rel, embedded[uri][rel], opts),
           );
         }
       }
@@ -151,7 +155,7 @@ function mergeEmbeddedStandaloneCollections(embedded, links, opts) {
           delete ret[uri][rel];
           merge(
             ret,
-            extractToVirtualKey(uri, rel, links[uri][rel], opts.embeddedStandaloneListKey),
+            extractToVirtualKey(uri, rel, links[uri][rel], opts),
           );
         }
       });

--- a/test/normalize.spec.js
+++ b/test/normalize.spec.js
@@ -804,7 +804,7 @@ describe('embedded', () => {
     expect(result).to.deep.equal(output);
   });
 
-  it('embedded standalone list without standalone link generates virtual key', () => {
+  it('embedded list with link array generates virtual key', () => {
     const json = {
       id: '2620',
       text: 'hello',
@@ -868,7 +868,72 @@ describe('embedded', () => {
     expect(result).to.deep.equal(output);
   });
 
-  it('can handle empty embedded collection with virtual keys', () => {
+  it('not generating virtual key if standalone link is provided', () => {
+    const json = {
+      id: '2620',
+      text: 'hello',
+      _embedded: {
+        questions: [
+          {
+            id: 295,
+            text: 'Why?',
+            _meta: {
+              expires_at: 1513868982,
+            },
+            _links: {
+              self: {
+                href: 'http://example.com/questions/295',
+              },
+            },
+          },
+        ],
+      },
+      _links: {
+        questions: {
+          href: 'http://example.com/questions?post=2620',
+        },
+        self: {
+          href: 'http://example.com/posts/2620',
+        },
+      },
+    };
+
+    const output = {
+      'http://example.com/posts/2620': {
+        id: '2620',
+        text: 'hello',
+        questions: {
+          href: 'http://example.com/questions?post=2620',
+        },
+        _meta: {
+          self: 'http://example.com/posts/2620',
+        },
+      },
+      'http://example.com/questions?post=2620': {
+        items: [
+          {
+            href: 'http://example.com/questions/295',
+          },
+        ],
+        _meta: {
+          self: 'http://example.com/questions?post=2620',
+        },
+      },
+      'http://example.com/questions/295': {
+        id: 295,
+        text: 'Why?',
+        _meta: {
+          self: 'http://example.com/questions/295',
+          expiresAt: 1513868982,
+        },
+      },
+    };
+    const result = normalize(json, { embeddedStandaloneListKey: 'items', embeddedStandaloneListVirtualKeys: true });
+
+    expect(result).to.deep.equal(output);
+  });
+
+  it('can handle empty embedded collection and missing link with virtual keys', () => {
     const json = {
       id: '2620',
       text: 'hello',
@@ -876,7 +941,6 @@ describe('embedded', () => {
         questions: [],
       },
       _links: {
-        questions: [],
         self: {
           href: 'http://example.com/posts/2620',
         },

--- a/test/normalize.spec.js
+++ b/test/normalize.spec.js
@@ -842,6 +842,7 @@ describe('embedded', () => {
         text: 'hello',
         questions: {
           href: 'http://example.com/posts/2620#questions',
+          virtual: true,
         },
         _meta: {
           self: 'http://example.com/posts/2620',
@@ -953,6 +954,7 @@ describe('embedded', () => {
         text: 'hello',
         questions: {
           href: 'http://example.com/posts/2620#questions',
+          virtual: true,
         },
         _meta: {
           self: 'http://example.com/posts/2620',

--- a/test/normalize.spec.js
+++ b/test/normalize.spec.js
@@ -869,6 +869,47 @@ describe('embedded', () => {
     expect(result).to.deep.equal(output);
   });
 
+  it('link array without embedded data generates virtual key', () => {
+    const json = {
+      id: '2620',
+      text: 'hello',
+      _links: {
+        questions: [
+          {
+            href: 'http://example.com/questions/295',
+          },
+        ],
+        self: {
+          href: 'http://example.com/posts/2620',
+        },
+      },
+    };
+
+    const output = {
+      'http://example.com/posts/2620': {
+        id: '2620',
+        text: 'hello',
+        questions: {
+          href: 'http://example.com/posts/2620#questions',
+          virtual: true,
+        },
+        _meta: {
+          self: 'http://example.com/posts/2620',
+        },
+      },
+      'http://example.com/posts/2620#questions': {
+        items: [
+          {
+            href: 'http://example.com/questions/295',
+          },
+        ],
+      },
+    };
+    const result = normalize(json, { embeddedStandaloneListKey: 'items', embeddedStandaloneListVirtualKeys: true });
+
+    expect(result).to.deep.equal(output);
+  });
+
   it('not generating virtual key if standalone link is provided', () => {
     const json = {
       id: '2620',

--- a/test/normalize.spec.js
+++ b/test/normalize.spec.js
@@ -745,7 +745,7 @@ describe('embedded', () => {
     expect(result).to.deep.equal(output);
   });
 
-  it('embedded list without standalone link ignores link array', () => {
+  it('prefers embedded list if corresponding link rel is not a single link', () => {
     const json = {
       id: '2620',
       text: 'hello',
@@ -804,211 +804,255 @@ describe('embedded', () => {
     expect(result).to.deep.equal(output);
   });
 
-  it('embedded list with link array generates virtual key', () => {
-    const json = {
-      id: '2620',
-      text: 'hello',
-      _embedded: {
-        questions: [
-          {
-            id: 295,
-            text: 'Why?',
-            _meta: {
-              expires_at: 1513868982,
-            },
-            _links: {
-              self: {
-                href: 'http://example.com/questions/295',
+  describe('virtual keys for anonymous embedded collections', () => {
+    it('embedded list with link array generates virtual key', () => {
+      const json = {
+        id: '2620',
+        text: 'hello',
+        _embedded: {
+          questions: [
+            {
+              id: 295,
+              text: 'Why?',
+              _meta: {
+                expires_at: 1513868982,
+              },
+              _links: {
+                self: {
+                  href: 'http://example.com/questions/295',
+                },
               },
             },
-          },
-        ],
-      },
-      _links: {
-        questions: [
-          {
-            href: 'http://example.com/questions/295',
-          },
-        ],
-        self: {
-          href: 'http://example.com/posts/2620',
+          ],
         },
-      },
-    };
-
-    const output = {
-      'http://example.com/posts/2620': {
-        id: '2620',
-        text: 'hello',
-        questions: {
-          href: 'http://example.com/posts/2620#questions',
-          virtual: true,
-        },
-        _meta: {
-          self: 'http://example.com/posts/2620',
-        },
-      },
-      'http://example.com/posts/2620#questions': {
-        items: [
-          {
-            href: 'http://example.com/questions/295',
-          },
-        ],
-      },
-      'http://example.com/questions/295': {
-        id: 295,
-        text: 'Why?',
-        _meta: {
-          self: 'http://example.com/questions/295',
-          expiresAt: 1513868982,
-        },
-      },
-    };
-    const result = normalize(json, { embeddedStandaloneListKey: 'items', embeddedStandaloneListVirtualKeys: true });
-
-    expect(result).to.deep.equal(output);
-  });
-
-  it('link array without embedded data generates virtual key', () => {
-    const json = {
-      id: '2620',
-      text: 'hello',
-      _links: {
-        questions: [
-          {
-            href: 'http://example.com/questions/295',
-          },
-        ],
-        self: {
-          href: 'http://example.com/posts/2620',
-        },
-      },
-    };
-
-    const output = {
-      'http://example.com/posts/2620': {
-        id: '2620',
-        text: 'hello',
-        questions: {
-          href: 'http://example.com/posts/2620#questions',
-          virtual: true,
-        },
-        _meta: {
-          self: 'http://example.com/posts/2620',
-        },
-      },
-      'http://example.com/posts/2620#questions': {
-        items: [
-          {
-            href: 'http://example.com/questions/295',
-          },
-        ],
-      },
-    };
-    const result = normalize(json, { embeddedStandaloneListKey: 'items', embeddedStandaloneListVirtualKeys: true });
-
-    expect(result).to.deep.equal(output);
-  });
-
-  it('not generating virtual key if standalone link is provided', () => {
-    const json = {
-      id: '2620',
-      text: 'hello',
-      _embedded: {
-        questions: [
-          {
-            id: 295,
-            text: 'Why?',
-            _meta: {
-              expires_at: 1513868982,
+        _links: {
+          questions: [
+            {
+              href: 'http://example.com/questions/295',
             },
-            _links: {
-              self: {
-                href: 'http://example.com/questions/295',
+          ],
+          self: {
+            href: 'http://example.com/posts/2620',
+          },
+        },
+      };
+
+      const output = {
+        'http://example.com/posts/2620': {
+          id: '2620',
+          text: 'hello',
+          questions: {
+            href: 'http://example.com/posts/2620#questions',
+            virtual: true,
+          },
+          _meta: {
+            self: 'http://example.com/posts/2620',
+          },
+        },
+        'http://example.com/posts/2620#questions': {
+          items: [
+            {
+              href: 'http://example.com/questions/295',
+            },
+          ],
+          _meta: {
+            self: 'http://example.com/posts/2620#questions',
+            virtual: true,
+          },
+        },
+        'http://example.com/questions/295': {
+          id: 295,
+          text: 'Why?',
+          _meta: {
+            self: 'http://example.com/questions/295',
+            expiresAt: 1513868982,
+          },
+        },
+      };
+      const result = normalize(json, { embeddedStandaloneListKey: 'items', embeddedStandaloneListVirtualKeys: true });
+
+      expect(result).to.deep.equal(output);
+    });
+
+    it('generates virtual key for link array without embedded data', () => {
+      const json = {
+        id: '2620',
+        text: 'hello',
+        _links: {
+          questions: [
+            {
+              href: 'http://example.com/questions/295',
+            },
+          ],
+          self: {
+            href: 'http://example.com/posts/2620',
+          },
+        },
+      };
+
+      const output = {
+        'http://example.com/posts/2620': {
+          id: '2620',
+          text: 'hello',
+          questions: {
+            href: 'http://example.com/posts/2620#questions',
+            virtual: true,
+          },
+          _meta: {
+            self: 'http://example.com/posts/2620',
+          },
+        },
+        'http://example.com/posts/2620#questions': {
+          items: [
+            {
+              href: 'http://example.com/questions/295',
+            },
+          ],
+          _meta: {
+            self: 'http://example.com/posts/2620#questions',
+            virtual: true,
+          },
+        },
+      };
+      const result = normalize(json, { embeddedStandaloneListKey: 'items', embeddedStandaloneListVirtualKeys: true });
+
+      expect(result).to.deep.equal(output);
+    });
+
+    it('does not generate virtual key if standalone link is provided', () => {
+      const json = {
+        id: '2620',
+        text: 'hello',
+        _embedded: {
+          questions: [
+            {
+              id: 295,
+              text: 'Why?',
+              _meta: {
+                expires_at: 1513868982,
+              },
+              _links: {
+                self: {
+                  href: 'http://example.com/questions/295',
+                },
               },
             },
+          ],
+        },
+        _links: {
+          questions: {
+            href: 'http://example.com/questions?post=2620',
           },
-        ],
-      },
-      _links: {
-        questions: {
-          href: 'http://example.com/questions?post=2620',
+          self: {
+            href: 'http://example.com/posts/2620',
+          },
         },
-        self: {
-          href: 'http://example.com/posts/2620',
-        },
-      },
-    };
+      };
 
-    const output = {
-      'http://example.com/posts/2620': {
+      const output = {
+        'http://example.com/posts/2620': {
+          id: '2620',
+          text: 'hello',
+          questions: {
+            href: 'http://example.com/questions?post=2620',
+          },
+          _meta: {
+            self: 'http://example.com/posts/2620',
+          },
+        },
+        'http://example.com/questions?post=2620': {
+          items: [
+            {
+              href: 'http://example.com/questions/295',
+            },
+          ],
+          _meta: {
+            self: 'http://example.com/questions?post=2620',
+          },
+        },
+        'http://example.com/questions/295': {
+          id: 295,
+          text: 'Why?',
+          _meta: {
+            self: 'http://example.com/questions/295',
+            expiresAt: 1513868982,
+          },
+        },
+      };
+      const result = normalize(json, { embeddedStandaloneListKey: 'items', embeddedStandaloneListVirtualKeys: true });
+
+      expect(result).to.deep.equal(output);
+    });
+
+    it('can handle empty embedded collection and missing link with virtual keys', () => {
+      const json = {
         id: '2620',
         text: 'hello',
-        questions: {
-          href: 'http://example.com/questions?post=2620',
+        _embedded: {
+          questions: [],
         },
-        _meta: {
-          self: 'http://example.com/posts/2620',
+        _links: {
+          self: {
+            href: 'http://example.com/posts/2620',
+          },
         },
-      },
-      'http://example.com/questions?post=2620': {
-        items: [
-          {
+      };
+
+      const output = {
+        'http://example.com/posts/2620': {
+          id: '2620',
+          text: 'hello',
+          questions: {
+            href: 'http://example.com/posts/2620#questions',
+            virtual: true,
+          },
+          _meta: {
+            self: 'http://example.com/posts/2620',
+          },
+        },
+        'http://example.com/posts/2620#questions': {
+          items: [],
+          _meta: {
+            self: 'http://example.com/posts/2620#questions',
+            virtual: true,
+          },
+        },
+      };
+      const result = normalize(json, { embeddedStandaloneListKey: 'items', embeddedStandaloneListVirtualKeys: true });
+
+      expect(result).to.deep.equal(output);
+    });
+
+    it('does not generate virtual key for single link without embedded data', () => {
+      const json = {
+        id: '2620',
+        text: 'hello',
+        _links: {
+          question: {
             href: 'http://example.com/questions/295',
           },
-        ],
-        _meta: {
-          self: 'http://example.com/questions?post=2620',
+          self: {
+            href: 'http://example.com/posts/2620',
+          },
         },
-      },
-      'http://example.com/questions/295': {
-        id: 295,
-        text: 'Why?',
-        _meta: {
-          self: 'http://example.com/questions/295',
-          expiresAt: 1513868982,
-        },
-      },
-    };
-    const result = normalize(json, { embeddedStandaloneListKey: 'items', embeddedStandaloneListVirtualKeys: true });
+      };
 
-    expect(result).to.deep.equal(output);
-  });
-
-  it('can handle empty embedded collection and missing link with virtual keys', () => {
-    const json = {
-      id: '2620',
-      text: 'hello',
-      _embedded: {
-        questions: [],
-      },
-      _links: {
-        self: {
-          href: 'http://example.com/posts/2620',
+      const output = {
+        'http://example.com/posts/2620': {
+          id: '2620',
+          text: 'hello',
+          question: {
+            href: 'http://example.com/questions/295',
+          },
+          _meta: {
+            self: 'http://example.com/posts/2620',
+          },
         },
-      },
-    };
+      };
+      const result = normalize(json, { embeddedStandaloneListKey: 'items', embeddedStandaloneListVirtualKeys: true });
 
-    const output = {
-      'http://example.com/posts/2620': {
-        id: '2620',
-        text: 'hello',
-        questions: {
-          href: 'http://example.com/posts/2620#questions',
-          virtual: true,
-        },
-        _meta: {
-          self: 'http://example.com/posts/2620',
-        },
-      },
-      'http://example.com/posts/2620#questions': {
-        items: [
-        ],
-      },
-    };
-    const result = normalize(json, { embeddedStandaloneListKey: 'items', embeddedStandaloneListVirtualKeys: true });
-
-    expect(result).to.deep.equal(output);
+      expect(result).to.deep.equal(output);
+    });
   });
 });
 

--- a/test/normalize.spec.js
+++ b/test/normalize.spec.js
@@ -613,6 +613,47 @@ describe('embedded', () => {
     expect(result).to.deep.equal(output);
   });
 
+  it('can handle empty embedded standalone list', () => {
+    const json = {
+      id: '2620',
+      text: 'hello',
+      _embedded: {
+        questions: [],
+      },
+      _links: {
+        questions: {
+          href: 'http://example.com/questions?post=2620',
+        },
+        self: {
+          href: 'http://example.com/posts/2620',
+        },
+      },
+    };
+
+    const output = {
+      'http://example.com/posts/2620': {
+        id: '2620',
+        text: 'hello',
+        questions: {
+          href: 'http://example.com/questions?post=2620',
+        },
+        _meta: {
+          self: 'http://example.com/posts/2620',
+        },
+      },
+      'http://example.com/questions?post=2620': {
+        items: [
+        ],
+        _meta: {
+          self: 'http://example.com/questions?post=2620',
+        },
+      },
+    };
+    const result = normalize(json, { embeddedStandaloneListKey: 'items' });
+
+    expect(result).to.deep.equal(output);
+  });
+
   it('nested embedded standalone lists', () => {
     const json = {
       id: '1111',
@@ -700,6 +741,165 @@ describe('embedded', () => {
       },
     };
     const result = normalize(json, { embeddedStandaloneListKey: 'items' });
+
+    expect(result).to.deep.equal(output);
+  });
+
+  it('embedded list without standalone link ignores link array', () => {
+    const json = {
+      id: '2620',
+      text: 'hello',
+      _embedded: {
+        questions: [
+          {
+            id: 295,
+            text: 'Why?',
+            _meta: {
+              expires_at: 1513868982,
+            },
+            _links: {
+              self: {
+                href: 'http://example.com/questions/295',
+              },
+            },
+          },
+        ],
+      },
+      _links: {
+        questions: [
+          {
+            href: 'http://example.com/questions/295',
+          },
+        ],
+        self: {
+          href: 'http://example.com/posts/2620',
+        },
+      },
+    };
+
+    const output = {
+      'http://example.com/posts/2620': {
+        id: '2620',
+        text: 'hello',
+        questions: [
+          {
+            href: 'http://example.com/questions/295',
+          },
+        ],
+        _meta: {
+          self: 'http://example.com/posts/2620',
+        },
+      },
+      'http://example.com/questions/295': {
+        id: 295,
+        text: 'Why?',
+        _meta: {
+          self: 'http://example.com/questions/295',
+          expiresAt: 1513868982,
+        },
+      },
+    };
+    const result = normalize(json, { embeddedStandaloneListKey: 'items' });
+
+    expect(result).to.deep.equal(output);
+  });
+
+  it('embedded standalone list without standalone link generates virtual key', () => {
+    const json = {
+      id: '2620',
+      text: 'hello',
+      _embedded: {
+        questions: [
+          {
+            id: 295,
+            text: 'Why?',
+            _meta: {
+              expires_at: 1513868982,
+            },
+            _links: {
+              self: {
+                href: 'http://example.com/questions/295',
+              },
+            },
+          },
+        ],
+      },
+      _links: {
+        questions: [
+          {
+            href: 'http://example.com/questions/295',
+          },
+        ],
+        self: {
+          href: 'http://example.com/posts/2620',
+        },
+      },
+    };
+
+    const output = {
+      'http://example.com/posts/2620': {
+        id: '2620',
+        text: 'hello',
+        questions: {
+          href: 'http://example.com/posts/2620#questions',
+        },
+        _meta: {
+          self: 'http://example.com/posts/2620',
+        },
+      },
+      'http://example.com/posts/2620#questions': {
+        items: [
+          {
+            href: 'http://example.com/questions/295',
+          },
+        ],
+      },
+      'http://example.com/questions/295': {
+        id: 295,
+        text: 'Why?',
+        _meta: {
+          self: 'http://example.com/questions/295',
+          expiresAt: 1513868982,
+        },
+      },
+    };
+    const result = normalize(json, { embeddedStandaloneListKey: 'items', embeddedStandaloneListVirtualKeys: true });
+
+    expect(result).to.deep.equal(output);
+  });
+
+  it('can handle empty embedded collection with virtual keys', () => {
+    const json = {
+      id: '2620',
+      text: 'hello',
+      _embedded: {
+        questions: [],
+      },
+      _links: {
+        questions: [],
+        self: {
+          href: 'http://example.com/posts/2620',
+        },
+      },
+    };
+
+    const output = {
+      'http://example.com/posts/2620': {
+        id: '2620',
+        text: 'hello',
+        questions: {
+          href: 'http://example.com/posts/2620#questions',
+        },
+        _meta: {
+          self: 'http://example.com/posts/2620',
+        },
+      },
+      'http://example.com/posts/2620#questions': {
+        items: [
+        ],
+      },
+    };
+    const result = normalize(json, { embeddedStandaloneListKey: 'items', embeddedStandaloneListVirtualKeys: true });
 
     expect(result).to.deep.equal(output);
   });

--- a/test/normalize.spec.js
+++ b/test/normalize.spec.js
@@ -869,7 +869,7 @@ describe('embedded', () => {
           },
         },
       };
-      const result = normalize(json, { embeddedStandaloneListKey: 'items', embeddedStandaloneListVirtualKeys: true });
+      const result = normalize(json, { embeddedStandaloneListKey: 'items', virtualSelfLinks: true });
 
       expect(result).to.deep.equal(output);
     });
@@ -914,7 +914,7 @@ describe('embedded', () => {
           },
         },
       };
-      const result = normalize(json, { embeddedStandaloneListKey: 'items', embeddedStandaloneListVirtualKeys: true });
+      const result = normalize(json, { embeddedStandaloneListKey: 'items', virtualSelfLinks: true });
 
       expect(result).to.deep.equal(output);
     });
@@ -979,7 +979,7 @@ describe('embedded', () => {
           },
         },
       };
-      const result = normalize(json, { embeddedStandaloneListKey: 'items', embeddedStandaloneListVirtualKeys: true });
+      const result = normalize(json, { embeddedStandaloneListKey: 'items', virtualSelfLinks: true });
 
       expect(result).to.deep.equal(output);
     });
@@ -1018,7 +1018,7 @@ describe('embedded', () => {
           },
         },
       };
-      const result = normalize(json, { embeddedStandaloneListKey: 'items', embeddedStandaloneListVirtualKeys: true });
+      const result = normalize(json, { embeddedStandaloneListKey: 'items', virtualSelfLinks: true });
 
       expect(result).to.deep.equal(output);
     });
@@ -1049,7 +1049,7 @@ describe('embedded', () => {
           },
         },
       };
-      const result = normalize(json, { embeddedStandaloneListKey: 'items', embeddedStandaloneListVirtualKeys: true });
+      const result = normalize(json, { embeddedStandaloneListKey: 'items', virtualSelfLinks: true });
 
       expect(result).to.deep.equal(output);
     });


### PR DESCRIPTION
This fixes the problem with empty embedded collections which don't come with an own standalone link. Such embedded collections can currently not be distinguished from normal array properties after normalization.

### To discuss
- naming of option `embeddedStandaloneListVirtualKeys`
- pattern for generation of virtual key
  - another fixed delimiter than `#`
  - hash
  - configurable delimiter
  - configurable key generation function
- add additional meta data in the virtual key, e.g. `_meta.embedded = true`? or is the missing self link already sufficient?
  the current proposal includes a `virtual` flag, which makes it easer to recognize, that the link is a generated/virtual link and not a real one

### ToDo
- [x] Adjust documentation

Also fixes a bug, if only `embeddedStandaloneListKey` is enabled (without virtual keys), but when the provided link is an array instead of a standalone link (see this test for further details: https://github.com/carlobeltrame/hal-json-normalizer/pull/64/files#diff-aead39d5dfee7fb3c9c4092038162577d24b4aa828af9213f89ca4f73c2cd5b4R748).