### PR TITLE
feat: add parent reference for virtual links

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,8 @@ console.log(normalize(json, { embeddedStandaloneListKey: 'items', virtualSelfLin
     _meta: {
       self: 'https://my.api.com/someEntity/1#comments',
       virtual: true,
+      parentResource: 'https://my.api.com/someEntity/1',
+      parentProperty: 'comments',
     },
   },
   'https://my.api.com/someEntity/1#users': {
@@ -445,6 +447,8 @@ console.log(normalize(json, { embeddedStandaloneListKey: 'items', virtualSelfLin
     _meta: {
       self: 'https://my.api.com/someEntity/1#users',
       virtual: true,
+      parentResource: 'https://my.api.com/someEntity/1',
+      parentProperty: 'comments',
     },
   },
   'https://my.api.com/comments/53204': {

--- a/README.md
+++ b/README.md
@@ -431,8 +431,8 @@ console.log(normalize(json, { embeddedStandaloneListKey: 'items', virtualSelfLin
     _meta: {
       self: 'https://my.api.com/someEntity/1#comments',
       virtual: true,
-      parentResource: 'https://my.api.com/someEntity/1',
-      parentProperty: 'comments',
+      owningResource: 'https://my.api.com/someEntity/1',
+      owningRelation: 'comments',
     },
   },
   'https://my.api.com/someEntity/1#users': {
@@ -447,8 +447,8 @@ console.log(normalize(json, { embeddedStandaloneListKey: 'items', virtualSelfLin
     _meta: {
       self: 'https://my.api.com/someEntity/1#users',
       virtual: true,
-      parentResource: 'https://my.api.com/someEntity/1',
-      parentProperty: 'comments',
+      owningResource: 'https://my.api.com/someEntity/1',
+      owningRelation: 'comments',
     },
   },
   'https://my.api.com/comments/53204': {

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -105,6 +105,8 @@ function extractToVirtualKey(uri, rel, content, opts) {
     [opts.metaKey]: {
       self: virtualKey,
       virtual: true,
+      parentResource: uri,
+      parentProperty: rel,
     },
   };
 

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -105,8 +105,8 @@ function extractToVirtualKey(uri, rel, content, opts) {
     [opts.metaKey]: {
       self: virtualKey,
       virtual: true,
-      parentResource: uri,
-      parentProperty: rel,
+      owningResource: uri,
+      owningRelation: rel,
     },
   };
 

--- a/test/normalize.spec.js
+++ b/test/normalize.spec.js
@@ -858,8 +858,8 @@ describe('embedded', () => {
           _meta: {
             self: 'http://example.com/posts/2620#questions',
             virtual: true,
-            parentResource: 'http://example.com/posts/2620',
-            parentProperty: 'questions',
+            owningResource: 'http://example.com/posts/2620',
+            owningRelation: 'questions',
           },
         },
         'http://example.com/questions/295': {
@@ -913,8 +913,8 @@ describe('embedded', () => {
           _meta: {
             self: 'http://example.com/posts/2620#questions',
             virtual: true,
-            parentResource: 'http://example.com/posts/2620',
-            parentProperty: 'questions',
+            owningResource: 'http://example.com/posts/2620',
+            owningRelation: 'questions',
           },
         },
       };
@@ -1019,8 +1019,8 @@ describe('embedded', () => {
           _meta: {
             self: 'http://example.com/posts/2620#questions',
             virtual: true,
-            parentResource: 'http://example.com/posts/2620',
-            parentProperty: 'questions',
+            owningResource: 'http://example.com/posts/2620',
+            owningRelation: 'questions',
           },
         },
       };
@@ -1059,6 +1059,111 @@ describe('embedded', () => {
 
       expect(result).to.deep.equal(output);
     });
+  });
+
+  it('can handle nested embedded lists', () => {
+    const json = {
+      id: '2620',
+      text: 'hello',
+      _embedded: {
+        questions: [
+          {
+            id: 295,
+            text: 'Why?',
+            _meta: {
+              expires_at: 1513868982,
+            },
+            _embedded: {
+              options: [{
+                id: 123,
+                text: 'Because.',
+                _links: {
+                  self: {
+                    href: 'http://example.com/options/123',
+                  },
+                },
+              }],
+            },
+            _links: {
+              self: {
+                href: 'http://example.com/questions/295',
+              },
+            },
+          },
+        ],
+      },
+      _links: {
+        questions: [
+          {
+            href: 'http://example.com/questions/295',
+          },
+        ],
+        self: {
+          href: 'http://example.com/posts/2620',
+        },
+      },
+    };
+
+    const output = {
+      'http://example.com/posts/2620': {
+        id: '2620',
+        text: 'hello',
+        questions: {
+          href: 'http://example.com/posts/2620#questions',
+          virtual: true,
+        },
+        _meta: {
+          self: 'http://example.com/posts/2620',
+        },
+      },
+      'http://example.com/posts/2620#questions': {
+        items: [
+          {
+            href: 'http://example.com/questions/295',
+          },
+        ],
+        _meta: {
+          self: 'http://example.com/posts/2620#questions',
+          virtual: true,
+          owningResource: 'http://example.com/posts/2620',
+          owningRelation: 'questions',
+        },
+      },
+      'http://example.com/questions/295': {
+        id: 295,
+        text: 'Why?',
+        options: {
+          href: 'http://example.com/questions/295#options',
+          virtual: true,
+        },
+        _meta: {
+          self: 'http://example.com/questions/295',
+          expiresAt: 1513868982,
+        },
+      },
+      'http://example.com/questions/295#options': {
+        items: [
+          {
+            href: 'http://example.com/options/123',
+          },
+        ],
+        _meta: {
+          self: 'http://example.com/questions/295#options',
+          virtual: true,
+          owningResource: 'http://example.com/questions/295',
+          owningRelation: 'options',
+        },
+      },
+      'http://example.com/options/123': {
+        id: 123,
+        text: 'Because.',
+        _meta: { self: 'http://example.com/options/123' },
+      },
+    };
+
+    const result = normalize(json, { embeddedStandaloneListKey: 'items', virtualSelfLinks: true });
+
+    expect(result).to.deep.equal(output);
   });
 });
 

--- a/test/normalize.spec.js
+++ b/test/normalize.spec.js
@@ -858,6 +858,8 @@ describe('embedded', () => {
           _meta: {
             self: 'http://example.com/posts/2620#questions',
             virtual: true,
+            parentResource: 'http://example.com/posts/2620',
+            parentProperty: 'questions',
           },
         },
         'http://example.com/questions/295': {
@@ -911,6 +913,8 @@ describe('embedded', () => {
           _meta: {
             self: 'http://example.com/posts/2620#questions',
             virtual: true,
+            parentResource: 'http://example.com/posts/2620',
+            parentProperty: 'questions',
           },
         },
       };
@@ -1015,6 +1019,8 @@ describe('embedded', () => {
           _meta: {
             self: 'http://example.com/posts/2620#questions',
             virtual: true,
+            parentResource: 'http://example.com/posts/2620',
+            parentProperty: 'questions',
           },
         },
       };


### PR DESCRIPTION
Adding parent references for virtual links as discussed here:
https://github.com/carlobeltrame/hal-json-normalizer/pull/64#issuecomment-1025112835

### Why is it needed?
I was trying to finalize https://github.com/ecamp/hal-json-vuex/pull/260/files
In `hal-json-vuex` we include the functionality to reload related resources after a delete operation. It's implemented by walking through the store, searching for references to the deleted resource and then calling `reload` for the related resources. However, `reload` doesn't know what to do for virtual links without the reference to the parent resource.

At the moment, reload actually tries to send a GET operation to the virtual link, which of course fails.

### Naming
Alternative names (some inspired by Doctrine terminology):
- owningResource
- owningProperty, owningResourceProperty, inversedBy