### PR TITLE
fix: ensure array properties are not handled as embedded properties

### DIFF
--- a/src/normalize.js
+++ b/src/normalize.js
@@ -118,50 +118,52 @@ function extractToVirtualKey(uri, rel, content, opts) {
   return ret;
 }
 
-function mergeEmbeddedStandaloneCollections(embedded, links, opts) {
+function mergeEmbeddedStandaloneCollections(json, uri, opts) {
   const ret = {};
+
+  const embedded = extractAllEmbedded(json, uri, opts);
+  const links = extractAllLinks(json, uri, opts);
+
   merge(ret, links);
   merge(ret, embedded);
 
-  keys(embedded).forEach((uri) => {
-    // check all embedded properties for embedded collections
-    keys(embedded[uri]).forEach((rel) => {
-      if (Array.isArray(embedded[uri][rel])) {
-        // standalone link provided (store embedded list as standalone link)
-        if (uri in links && rel in links[uri] && isSingleLink(links[uri][rel])) {
-          ret[uri][rel] = links[uri][rel];
-          ret[links[uri][rel].href] = {
-            [opts.embeddedStandaloneListKey]: embedded[uri][rel],
-            [opts.metaKey]: { self: links[uri][rel].href },
-          };
-        } else if (opts.virtualSelfLinks && rel !== opts.embeddedStandaloneListKey) {
-          // no standalone link provided --> generate virtual key
-          delete ret[uri][rel];
-          merge(
-            ret,
-            extractToVirtualKey(uri, rel, embedded[uri][rel], opts),
-          );
-        }
+  // check all embedded properties for embedded collections
+  keys(embedded[uri]).forEach((rel) => {
+    if (Array.isArray(embedded[uri][rel])) {
+      // standalone link provided (store embedded list as standalone link)
+      if (uri in links && rel in links[uri] && isSingleLink(links[uri][rel])) {
+        ret[uri][rel] = links[uri][rel];
+        ret[links[uri][rel].href] = {
+          [opts.embeddedStandaloneListKey]: embedded[uri][rel],
+          [opts.metaKey]: { self: links[uri][rel].href },
+        };
+      } else if (opts.virtualSelfLinks && rel !== opts.embeddedStandaloneListKey) {
+        // no standalone link provided --> generate virtual key
+        delete ret[uri][rel];
+        merge(
+          ret,
+          extractToVirtualKey(uri, rel, embedded[uri][rel], opts),
+        );
       }
-    });
-
-    // also check remaining link properties to search for a possible collection
-    // which is not embedded
-    if (opts.virtualSelfLinks) {
-      difference(
-        keys(links[uri]),
-        [...keys(embedded[uri]), opts.embeddedStandaloneListKey],
-      ).forEach((rel) => {
-        if (Array.isArray(links[uri][rel])) {
-          delete ret[uri][rel];
-          merge(
-            ret,
-            extractToVirtualKey(uri, rel, links[uri][rel], opts),
-          );
-        }
-      });
     }
   });
+
+  // also check remaining link properties to search for a possible collection
+  // which is not embedded
+  if (opts.virtualSelfLinks) {
+    difference(
+      keys(links[uri]),
+      [...keys(embedded[uri]), opts.embeddedStandaloneListKey],
+    ).forEach((rel) => {
+      if (Array.isArray(links[uri][rel])) {
+        delete ret[uri][rel];
+        merge(
+          ret,
+          extractToVirtualKey(uri, rel, links[uri][rel], opts),
+        );
+      }
+    });
+  }
 
   return ret;
 }
@@ -188,11 +190,8 @@ extractResource = (json, opts) => {
     }
   });
 
-  const embedded = extractAllEmbedded(json, uri, opts);
-  const links = extractAllLinks(json, uri, opts);
-
   if (opts.embeddedStandaloneListKey) {
-    merge(ret, mergeEmbeddedStandaloneCollections(embedded, links, opts));
+    merge(ret, mergeEmbeddedStandaloneCollections(json, uri, opts));
   } else {
     merge(ret, extractAllLinks(json, uri, opts));
     merge(ret, extractAllEmbedded(json, uri, opts));

--- a/test/normalize.spec.js
+++ b/test/normalize.spec.js
@@ -1065,6 +1065,10 @@ describe('embedded', () => {
     const json = {
       id: '2620',
       text: 'hello',
+      outerArrayProperty: [{
+        outer: true,
+      }],
+      emptyOuterArrayProperty: [],
       _embedded: {
         questions: [
           {
@@ -1081,6 +1085,10 @@ describe('embedded', () => {
               options: [{
                 id: 123,
                 text: 'Because.',
+                innerArrayProperty: [{
+                  outer: false,
+                }],
+                emptyInnerArrayProperty: [],
                 _links: {
                   self: {
                     href: 'http://example.com/options/123',
@@ -1112,6 +1120,10 @@ describe('embedded', () => {
       'http://example.com/posts/2620': {
         id: '2620',
         text: 'hello',
+        outerArrayProperty: [{
+          outer: true,
+        }],
+        emptyOuterArrayProperty: [],
         questions: {
           href: 'http://example.com/posts/2620#questions',
           virtual: true,
@@ -1165,6 +1177,10 @@ describe('embedded', () => {
       'http://example.com/options/123': {
         id: 123,
         text: 'Because.',
+        innerArrayProperty: [{
+          outer: false,
+        }],
+        emptyInnerArrayProperty: [],
         _meta: { self: 'http://example.com/options/123' },
       },
     };

--- a/test/normalize.spec.js
+++ b/test/normalize.spec.js
@@ -1073,6 +1073,10 @@ describe('embedded', () => {
             _meta: {
               expires_at: 1513868982,
             },
+            arrayProperty: [{
+              test: 123,
+            }],
+            emptyArrayProperty: [],
             _embedded: {
               options: [{
                 id: 123,
@@ -1132,6 +1136,10 @@ describe('embedded', () => {
       'http://example.com/questions/295': {
         id: 295,
         text: 'Why?',
+        arrayProperty: [{
+          test: 123,
+        }],
+        emptyArrayProperty: [],
         options: {
           href: 'http://example.com/questions/295#options',
           virtual: true,


### PR DESCRIPTION
Currently, nested array properties can be incorrectly interpreted as embedded collections, when `virtualSelfLinks` is set to `true`.